### PR TITLE
Fix fluid dupe #103

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -13,6 +13,6 @@ fmp.version=1.2.0.345
 
 mekanism.version=8.1.7.5
 computercraft.version=1.74.2
-opencomputers.version=1.5.21.41
+opencomputers.version=1.5.22.46
 
 waila.version=1.5.10

--- a/src/net/bdew/pressure/pressurenet/PressureConnection.scala
+++ b/src/net/bdew/pressure/pressurenet/PressureConnection.scala
@@ -40,7 +40,7 @@ case class PressureConnection(origin: IPressureInject, side: ForgeDirection, til
           toPush -= target.eject(new FluidStack(fluid.getFluid, toPush), doPush)
           if (toPush <= 0) return fluid.amount
         }
-        toPush - fluid.amount
+        fluid.amount - toPush
       } else {
         val maxFill = tiles.map(target => target -> target.eject(fluid.copy(), false)).toMap
         val totalFill = maxFill.values.sum


### PR DESCRIPTION
This commit will fix unlimitied fluid dupe when tank controller have less than 10 mb left. All versions affected with this issue. 